### PR TITLE
Handle cancel event on Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -23,7 +23,7 @@
         <source-file src="src/android/AdvancedImagePickerErrorCodes.java" target-dir="src/de/einfachhans/AdvancedImagePicker"/>
         <framework src="src/android/build.gradle" custom="true" type="gradleReference"/>
 
-        <preference name="ANDROID_IMAGE_PICKER_VERSION" default="1.2.2" />
+        <preference name="ANDROID_IMAGE_PICKER_VERSION" default="1.2.8" />
         <framework src="io.github.ParkSangGwon:tedimagepicker:$ANDROID_IMAGE_PICKER_VERSION"/>
     </platform>
 

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 This [Cordova](https://cordova.apache.org) Plugin is for a better (multiple) ImagePicker with more options.
 
 It currently uses [Yummypets/YPImagePicker](https://github.com/Yummypets/YPImagePicker) (Version `4.5.0`) on iOS and 
-[ParkSangGwon/TedImagePicker](https://github.com/ParkSangGwon/TedImagePicker) (Default-Version `1.2.2`) on Android. 
+[ParkSangGwon/TedImagePicker](https://github.com/ParkSangGwon/TedImagePicker) (Default-Version `1.2.8`) on Android. 
 
 **This Plugin is in active development!**
 
@@ -21,6 +21,7 @@ Please consider donating if you're using this plugin in an app that makes you mo
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Content**
 
+- [Advanced ImagePicker Cordova Plugin](#advanced-imagepicker-cordova-plugin)
 - [Install](#install)
   - [Requirements](#requirements)
   - [Android](#android)
@@ -34,6 +35,8 @@ Please consider donating if you're using this plugin in an app that makes you mo
 - [Api](#api)
   - [All platforms](#all-platforms)
     - [present](#present)
+      - [Parameters:](#parameters)
+      - [SuccessType:](#successtype)
   - [iOS](#ios-2)
     - [cleanup](#cleanup)
 - [Quirks](#quirks)
@@ -66,7 +69,7 @@ I developed it, testing with **cordova-ios@6.1.0**.
 
 ## Android
 
-- ANDROID_IMAGE_PICKER_VERSION - Version of `gun0912.ted:tedimagepicker` / default to `1.1.4` 
+- ANDROID_IMAGE_PICKER_VERSION - Version of `gun0912.ted:tedimagepicker` / default to `1.2.8` 
 
 ## iOS
 

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,6 @@ Please consider donating if you're using this plugin in an app that makes you mo
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Content**
 
-- [Advanced ImagePicker Cordova Plugin](#advanced-imagepicker-cordova-plugin)
 - [Install](#install)
   - [Requirements](#requirements)
   - [Android](#android)
@@ -35,8 +34,6 @@ Please consider donating if you're using this plugin in an app that makes you mo
 - [Api](#api)
   - [All platforms](#all-platforms)
     - [present](#present)
-      - [Parameters:](#parameters)
-      - [SuccessType:](#successtype)
   - [iOS](#ios-2)
     - [cleanup](#cleanup)
 - [Quirks](#quirks)

--- a/src/android/AdvancedImagePicker.java
+++ b/src/android/AdvancedImagePicker.java
@@ -82,6 +82,9 @@ public class AdvancedImagePicker extends CordovaPlugin {
                 .zoomIndicator(zoomIndicator)
                 .errorListener(error -> {
                     this.returnError(AdvancedImagePickerErrorCodes.UnknownError, error.getMessage());
+                })
+                .cancelListener(() -> {
+                    this.returnCancel();
                 });
 
         if (!scrollIndicatorDateFormat.equals("")) {
@@ -191,6 +194,14 @@ public class AdvancedImagePicker extends CordovaPlugin {
             resultMap.put("message", message == null ? "" : message);
             _callbackContext.error(new JSONObject(resultMap));
             _callbackContext = null;
+        }
+    }
+
+    private void returnCancel() {
+        if (this._callbackContext != null) {
+            // Return empty array on cancel
+            JSONArray result = new JSONArray();
+            this._callbackContext.success(result);
         }
     }
 }


### PR DESCRIPTION
[TedImagePicker](https://github.com/ParkSangGwon/TedImagePicker) exposes `cancelListener` since version 1.2.6. If we upgrade the dependency we can easily support the cancel event (#11) by returning an empty array to the user. 